### PR TITLE
Fix goat feedings retrieval

### DIFF
--- a/services/messaging_service.py
+++ b/services/messaging_service.py
@@ -468,7 +468,7 @@ class MessagingService:
                 try:
                     from services.goat_service import GoatStateService
                     if hasattr(self, 'goat_service') and isinstance(self.goat_service, GoatStateService):
-                        feedings = await self.goat_service.get_feedings()
+                        feedings = await self.goat_service.get_feedings_count()
                         message_data["goat_feedings"] = feedings
                 except Exception as e:
                     self.logger.error(f"Error fetching feedings for message: {e}")


### PR DESCRIPTION
## Summary
- use `get_feedings_count` in `make_messages` when retrieving today's goat feedings

## Testing
- `python -m py_compile services/messaging_service.py`

------
https://chatgpt.com/codex/tasks/task_e_684c5b6105a08333bb42ba9c121df9ca